### PR TITLE
refactor:use interfaces instead of classes for wails bindings

### DIFF
--- a/cmd/gomander/frontend/src/contracts/service.ts
+++ b/cmd/gomander/frontend/src/contracts/service.ts
@@ -15,7 +15,7 @@ import {
   SaveUserConfig,
   StopCommand,
 } from "../../wailsjs/go/app/App";
-import { project } from "../../wailsjs/go/models.ts";
+import type { project } from "../../wailsjs/go/models.ts";
 import { EventsOff, EventsOn } from "../../wailsjs/runtime";
 
 export const dataService = {

--- a/cmd/gomander/frontend/src/contracts/types.ts
+++ b/cmd/gomander/frontend/src/contracts/types.ts
@@ -1,4 +1,5 @@
-import { config, event, project } from "../../wailsjs/go/models.ts";
+import type { config, project } from "../../wailsjs/go/models.ts";
+import { event } from "../../wailsjs/go/models.ts";
 
 // Types
 export type Command = project.Command;

--- a/cmd/gomander/frontend/wailsjs/go/models.ts
+++ b/cmd/gomander/frontend/wailsjs/go/models.ts
@@ -1,18 +1,8 @@
 export namespace config {
 	
-	export class UserConfig {
+	export interface UserConfig {
 	    environmentPaths: string[];
 	    lastOpenedProjectId: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new UserConfig(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.environmentPaths = source["environmentPaths"];
-	        this.lastOpenedProjectId = source["lastOpenedProjectId"];
-	    }
 	}
 
 }
@@ -34,75 +24,22 @@ export namespace event {
 
 export namespace project {
 	
-	export class Command {
+	export interface Command {
 	    id: string;
 	    name: string;
 	    command: string;
 	    workingDirectory: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new Command(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.id = source["id"];
-	        this.name = source["name"];
-	        this.command = source["command"];
-	        this.workingDirectory = source["workingDirectory"];
-	    }
 	}
-	export class CommandGroup {
+	export interface CommandGroup {
 	    id: string;
 	    name: string;
 	    commands: string[];
-	
-	    static createFrom(source: any = {}) {
-	        return new CommandGroup(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.id = source["id"];
-	        this.name = source["name"];
-	        this.commands = source["commands"];
-	    }
 	}
-	export class Project {
+	export interface Project {
 	    id: string;
 	    name: string;
 	    commands: Record<string, Command>;
 	    commandGroups: CommandGroup[];
-	
-	    static createFrom(source: any = {}) {
-	        return new Project(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.id = source["id"];
-	        this.name = source["name"];
-	        this.commands = this.convertValues(source["commands"], Command, true);
-	        this.commandGroups = this.convertValues(source["commandGroups"], CommandGroup);
-	    }
-	
-		convertValues(a: any, classs: any, asMap: boolean = false): any {
-		    if (!a) {
-		        return a;
-		    }
-		    if (a.slice && a.map) {
-		        return (a as any[]).map(elem => this.convertValues(elem, classs));
-		    } else if ("object" === typeof a) {
-		        if (asMap) {
-		            for (const key of Object.keys(a)) {
-		                a[key] = new classs(a[key]);
-		            }
-		            return a;
-		        }
-		        return new classs(a);
-		    }
-		    return a;
-		}
 	}
 
 }

--- a/cmd/gomander/wails.json
+++ b/cmd/gomander/wails.json
@@ -7,6 +7,11 @@
   "build:dir": "../../build",
   "frontend:dev:watcher": "pnpm run dev",
   "frontend:dev:serverUrl": "auto",
+  "bindings": {
+    "ts_generation": {
+      "outputType": "interfaces"
+    }
+  },
   "author": {
     "name": "",
     "email": ""


### PR DESCRIPTION
Interfaces are simpler and if we want to create classes in the client side, we can do it later having full ownership of them in the client.