### PR TITLE
refactor: add setter for opened project id

### DIFF
--- a/internal/app/commandgrouphandlers_test.go
+++ b/internal/app/commandgrouphandlers_test.go
@@ -16,18 +16,14 @@ import (
 func TestApp_GetCommandGroups(t *testing.T) {
 	t.Run("Should return the command groups provided by the command group repository", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData := testutils.
 			NewCommandGroup().
@@ -53,8 +49,6 @@ func TestApp_CreateCommandGroup(t *testing.T) {
 	t.Run("Should create a command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
 		mockEventEmitter := new(MockEventEmitter)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
@@ -63,11 +57,9 @@ func TestApp_CreateCommandGroup(t *testing.T) {
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
 			EventEmitter:           mockEventEmitter,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		otherCommandGroupData := testutils.
 			NewCommandGroup().
@@ -103,19 +95,15 @@ func TestApp_CreateCommandGroup(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to retrieve existing command groups", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData := testutils.
 			NewCommandGroup().
@@ -135,19 +123,15 @@ func TestApp_CreateCommandGroup(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to save the command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData := testutils.
 			NewCommandGroup().
@@ -172,8 +156,6 @@ func TestApp_UpdateCommandGroup(t *testing.T) {
 	t.Run("Should update a command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
 		mockEventEmitter := new(MockEventEmitter)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
@@ -181,11 +163,9 @@ func TestApp_UpdateCommandGroup(t *testing.T) {
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
 			EventEmitter:           mockEventEmitter,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData := testutils.
 			NewCommandGroup().
@@ -207,19 +187,15 @@ func TestApp_UpdateCommandGroup(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to update the command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData := testutils.
 			NewCommandGroup().
@@ -241,8 +217,6 @@ func TestApp_DeleteCommandGroup(t *testing.T) {
 	t.Run("Should delete a command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
 		mockEventEmitter := new(MockEventEmitter)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
@@ -250,11 +224,9 @@ func TestApp_DeleteCommandGroup(t *testing.T) {
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
 			EventEmitter:           mockEventEmitter,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData := testutils.
 			NewCommandGroup().
@@ -276,19 +248,15 @@ func TestApp_DeleteCommandGroup(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to delete the command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData := testutils.
 			NewCommandGroup().
@@ -311,8 +279,6 @@ func TestApp_DeleteCommandGroup(t *testing.T) {
 func TestApp_ReorderCommandGroups(t *testing.T) {
 	t.Run("Should reorder command groups based on the provided IDs", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockEventEmitter := new(MockEventEmitter)
 
 		projectId := "project1"
@@ -320,12 +286,10 @@ func TestApp_ReorderCommandGroups(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 			EventEmitter:           mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData1 := testutils.
 			NewCommandGroup().
@@ -362,19 +326,15 @@ func TestApp_ReorderCommandGroups(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to retrieve existing command groups", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		newOrder := []string{"group1", "group2"}
 
@@ -384,19 +344,15 @@ func TestApp_ReorderCommandGroups(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to update a command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandGroupData1 := testutils.
 			NewCommandGroup().
@@ -424,8 +380,6 @@ func TestApp_ReorderCommandGroups(t *testing.T) {
 func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 	t.Run("Should remove command from command groups", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockEventEmitter := new(MockEventEmitter)
 
 		projectId := "project1"
@@ -433,12 +387,10 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 			EventEmitter:           mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandData := testutils.
 			NewCommand().
@@ -481,8 +433,6 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 	})
 	t.Run("Should remove remove a command group if it becomes empty", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockEventEmitter := new(MockEventEmitter)
 
 		projectId := "project1"
@@ -490,12 +440,10 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 			EventEmitter:           mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandData := testutils.
 			NewCommand().
@@ -537,8 +485,6 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to retrieve command groups", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -547,13 +493,11 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 			Logger:                 mockLogger,
 			EventEmitter:           mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandData := testutils.
 			NewCommand().
@@ -575,8 +519,6 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to update command groups", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockEventEmitter := new(MockEventEmitter)
 		mockLogger := new(MockLogger)
 
@@ -585,13 +527,11 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 			EventEmitter:           mockEventEmitter,
 			Logger:                 mockLogger,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandData := testutils.
 			NewCommand().
@@ -635,8 +575,6 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 	})
 	t.Run("Should return an error if failing to delete a command group", func(t *testing.T) {
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockEventEmitter := new(MockEventEmitter)
 		mockLogger := new(MockLogger)
 
@@ -645,13 +583,11 @@ func TestApp_RemoveCommandFromCommandGroups(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 			EventEmitter:           mockEventEmitter,
 			Logger:                 mockLogger,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandData := testutils.
 			NewCommand().

--- a/internal/app/commandhandlers_test.go
+++ b/internal/app/commandhandlers_test.go
@@ -51,18 +51,14 @@ func (m *MockCommandRepository) Delete(commandId string) error {
 func TestApp_GetCommands(t *testing.T) {
 	t.Run("Should return the commands provided by the repository", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 
 		projectId := "project1"
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		command1Data := testutils.
 			NewCommand().
@@ -94,8 +90,6 @@ func TestApp_GetCommands(t *testing.T) {
 func TestApp_AddCommand(t *testing.T) {
 	t.Run("Should add the command", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -103,13 +97,11 @@ func TestApp_AddCommand(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		existingCommandData := testutils.
 			NewCommand().
@@ -144,8 +136,7 @@ func TestApp_AddCommand(t *testing.T) {
 	})
 	t.Run("Should return an error if fails to get all commands", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -153,13 +144,11 @@ func TestApp_AddCommand(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		newCommandData := testutils.
 			NewCommand().
@@ -182,8 +171,7 @@ func TestApp_AddCommand(t *testing.T) {
 	})
 	t.Run("Should return an error if fails to create commands", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -191,13 +179,11 @@ func TestApp_AddCommand(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		existingCommandData := testutils.
 			NewCommand().
@@ -235,8 +221,7 @@ func TestApp_RemoveCommand(t *testing.T) {
 	t.Run("Should remove the command", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -245,13 +230,11 @@ func TestApp_RemoveCommand(t *testing.T) {
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository:      mockCommandRepository,
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
 			Logger:                 mockLogger,
 			EventEmitter:           mockEventEmitter,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandId := "command1"
 
@@ -276,8 +259,7 @@ func TestApp_RemoveCommand(t *testing.T) {
 	})
 	t.Run("Should return an error if fails to remove the command", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
@@ -286,14 +268,12 @@ func TestApp_RemoveCommand(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository:      mockCommandRepository,
-			ConfigRepository:       mockConfigRepository,
-			ProjectRepository:      mockProjectRepository,
 			Logger:                 mockLogger,
 			EventEmitter:           mockEventEmitter,
 			CommandGroupRepository: mockCommandGroupRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandId := "command1"
 
@@ -309,8 +289,6 @@ func TestApp_RemoveCommand(t *testing.T) {
 
 		mock.AssertExpectationsForObjects(t,
 			mockCommandRepository,
-			mockConfigRepository,
-			mockProjectRepository,
 			mockLogger,
 			mockEventEmitter,
 			mockCommandGroupRepository,
@@ -319,8 +297,7 @@ func TestApp_RemoveCommand(t *testing.T) {
 	t.Run("Should return an error if fails to remove the command from a command group (e.g. fails to retrieve command groups)", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
 		mockCommandGroupRepository := new(MockCommandGroupRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -329,13 +306,11 @@ func TestApp_RemoveCommand(t *testing.T) {
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository:      mockCommandRepository,
 			CommandGroupRepository: mockCommandGroupRepository,
-			ConfigRepository:       mockConfigRepository,
 			Logger:                 mockLogger,
 			EventEmitter:           mockEventEmitter,
-			ProjectRepository:      mockProjectRepository,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandId := "command1"
 
@@ -359,8 +334,7 @@ func TestApp_RemoveCommand(t *testing.T) {
 func TestApp_EditCommand(t *testing.T) {
 	t.Run("Should edit the command", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -368,13 +342,11 @@ func TestApp_EditCommand(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandData := testutils.
 			NewCommand().
@@ -400,8 +372,7 @@ func TestApp_EditCommand(t *testing.T) {
 	})
 	t.Run("Should return an error if fails to edit the command", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -409,13 +380,11 @@ func TestApp_EditCommand(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		commandData := testutils.
 			NewCommand().
@@ -443,8 +412,7 @@ func TestApp_EditCommand(t *testing.T) {
 func TestApp_ReorderCommands(t *testing.T) {
 	t.Run("Should reorder commands", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -452,13 +420,11 @@ func TestApp_ReorderCommands(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		cmd1 := testutils.NewCommand().WithProjectId(projectId).WithPosition(0)
 		cmd2 := testutils.NewCommand().WithProjectId(projectId).WithPosition(1)
@@ -496,8 +462,7 @@ func TestApp_ReorderCommands(t *testing.T) {
 	})
 	t.Run("Should return an error if fails to retrieve commands", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -505,13 +470,11 @@ func TestApp_ReorderCommands(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		mockCommandRepository.On("GetAll", projectId).Return(
 			make([]commanddomain.Command, 0),
@@ -531,8 +494,7 @@ func TestApp_ReorderCommands(t *testing.T) {
 	})
 	t.Run("Should return an error if fails to update commands", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
-		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
+
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -540,13 +502,11 @@ func TestApp_ReorderCommands(t *testing.T) {
 		a := app.NewApp()
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
-			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
 
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		cmd1 := testutils.NewCommand().WithProjectId(projectId).WithPosition(0)
 		cmd2 := testutils.NewCommand().WithProjectId(projectId).WithPosition(1)
@@ -679,7 +639,6 @@ func TestApp_RunCommand(t *testing.T) {
 	t.Run("Should return an error if failing to retrieve the user config", func(t *testing.T) {
 		mockCommandRepository := new(MockCommandRepository)
 		mockConfigRepository := new(MockUserConfigRepository)
-		mockProjectRepository := new(MockProjectRepository)
 		mockLogger := new(MockLogger)
 		mockEventEmitter := new(MockEventEmitter)
 
@@ -687,7 +646,6 @@ func TestApp_RunCommand(t *testing.T) {
 		a.LoadDependencies(app.Dependencies{
 			CommandRepository: mockCommandRepository,
 			ConfigRepository:  mockConfigRepository,
-			ProjectRepository: mockProjectRepository,
 			Logger:            mockLogger,
 			EventEmitter:      mockEventEmitter,
 		})
@@ -728,7 +686,7 @@ func TestApp_RunCommand(t *testing.T) {
 		})
 
 		projectId := "project1"
-		openProjectHelper(t, mockConfigRepository, mockProjectRepository, a, projectId)
+		a.SetOpenProjectId(projectId)
 
 		cmdData := testutils.NewCommand().WithProjectId(projectId).Data()
 		cmd := commandDataToDomain(cmdData)

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -18,7 +18,7 @@ func (a *App) Startup(ctx context.Context) {
 		panic(err)
 	}
 
-	a.openedProjectId = config.LastOpenedProjectId
+	a.SetOpenProjectId(config.LastOpenedProjectId)
 
 	a.logger.Info("Configuration loaded successfully")
 }

--- a/internal/app/projecthandlers.go
+++ b/internal/app/projecthandlers.go
@@ -31,7 +31,7 @@ func (a *App) OpenProject(projectConfigId string) error {
 		return err
 	}
 
-	a.openedProjectId = projectConfigId
+	a.SetOpenProjectId(projectConfigId)
 
 	return nil
 }
@@ -70,7 +70,7 @@ func (a *App) CloseProject() error {
 		return err
 	}
 
-	a.openedProjectId = ""
+	a.SetOpenProjectId("")
 
 	return nil
 }
@@ -94,4 +94,8 @@ func (a *App) DeleteProject(projectConfigId string) error {
 	}
 
 	return nil
+}
+
+func (a *App) SetOpenProjectId(projectId string) {
+	a.openedProjectId = projectId
 }

--- a/internal/app/shared_test.go
+++ b/internal/app/shared_test.go
@@ -1,12 +1,8 @@
 package app_test
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gomander/internal/app"
 	commanddomain "gomander/internal/command/domain"
 	commandgroupdomain "gomander/internal/commandgroup/domain"
 	"gomander/internal/config/domain"
@@ -59,22 +55,6 @@ func (m *MockUserConfigRepository) GetOrCreate() (*domain.Config, error) {
 func (m *MockUserConfigRepository) Update(config *domain.Config) error {
 	args := m.Called(config)
 	return args.Error(0)
-}
-
-func openProjectHelper(t *testing.T, mockConfigRepository *MockUserConfigRepository, mockProjectRepository *MockProjectRepository, a *app.App, projectId string) {
-	t.Helper()
-	mockProjectRepository.On("Get", projectId).Return(&projectdomain.Project{
-		Id:   projectId,
-		Name: "Test Project",
-	}, nil).Once()
-	mockConfigRepository.On("GetOrCreate").Return(&domain.Config{
-		LastOpenedProjectId: "",
-		EnvironmentPaths:    make([]domain.EnvironmentPath, 0),
-	}, nil).Once()
-	mockConfigRepository.On("Update", mock.Anything).Once().Return(nil)
-
-	err := a.OpenProject(projectId)
-	assert.NoError(t, err)
 }
 
 type MockCommandGroupRepository struct {


### PR DESCRIPTION
This pull request refactors the test setup in `internal/app/commandhandlers_test.go` and `internal/app/commandgrouphandlers_test.go` to simplify how the open project is set in tests. Instead of mocking and injecting `ConfigRepository` and `ProjectRepository` dependencies and using the `openProjectHelper`, the tests now directly set the open project ID using `a.SetOpenProjectId(projectId)`. This streamlines the test code and removes unnecessary mock objects and helper calls.

Test setup simplification:

* Removed the use of `MockUserConfigRepository` and `MockProjectRepository` from all test cases in both `commandhandlers_test.go` and `commandgrouphandlers_test.go`, reducing boilerplate and simplifying dependency injection. [[1]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL54-R61) [[2]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL97-R104) [[3]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL147-R151) [[4]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL185-R186) [[5]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL19-R26) [[6]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL56-L57) [[7]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL66-R62) [[8]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL106-R106) [[9]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL138-R134) [[10]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL175-R168) [[11]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL210-R198) [[12]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL244-R229) [[13]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL279-R259) [[14]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL314-R292) [[15]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL365-R337) [[16]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL387-R355) [[17]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL427-R393) [[18]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL484-R446) [[19]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL540-L541) [[20]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL550-R500) [[21]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL578-L579) [[22]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL588-R534) [[23]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL638-L639) [[24]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL648-R590)
* Replaced calls to `openProjectHelper` with direct calls to `a.SetOpenProjectId(projectId)`, making the tests more straightforward and focused on their primary logic. [[1]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL54-R61) [[2]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL97-R104) [[3]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL147-R151) [[4]](diffhunk://#diff-a6de1233415dee1648d951c338ca0bd9678051edea907eab3f8cf9a2ebdaae8aL185-R186) [[5]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL19-R26) [[6]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL56-L57) [[7]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL66-R62) [[8]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL106-R106) [[9]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL138-R134) [[10]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL175-R168) [[11]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL210-R198) [[12]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL244-R229) [[13]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL279-R259) [[14]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL314-R292) [[15]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL365-R337) [[16]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL387-R355) [[17]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL427-R393) [[18]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL484-R446) [[19]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL540-L541) [[20]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL550-R500) [[21]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL578-L579) [[22]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL588-R534) [[23]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL638-L639) [[24]](diffhunk://#diff-691e05f7b907401e9612f73f01f4699d1102b76e9f5c0fb9900f43b0d5f9e77eL648-R590)