### PR TITLE
feat: send command as first line

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -82,6 +82,7 @@ func (c *DefaultRunner) RunCommand(command *domain.Command, environmentPaths []s
 		wg:  &wg,
 	}
 
+	c.sendStartingLine(command)
 	if err := cmd.Start(); err != nil {
 		c.sendStreamErrorWhileStartingCommand(command, err)
 		return err
@@ -144,6 +145,13 @@ func (c *DefaultRunner) RunCommand(command *domain.Command, environmentPaths []s
 	}()
 
 	return nil
+}
+
+func (c *DefaultRunner) sendStartingLine(command *domain.Command) {
+	c.eventEmitter.EmitEvent(event.NewLogEntry, map[string]string{
+		"id":   command.Id,
+		"line": "\033[1;36m" + command.Command + "\033[0m",
+	})
 }
 
 func (c *DefaultRunner) StopRunningCommand(id string) error {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner_test
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +37,13 @@ func TestDefaultRunner_RunCommand(t *testing.T) {
 		mockEmitterLogEntry(emitter, commandId, "a")
 		mockEmitterLogEntry(emitter, commandId, "b")
 		mockEmitterLogEntry(emitter, commandId, "c")
+
+		// Check first line
+		emitter.On("EmitEvent", event.NewLogEntry, mock.MatchedBy(func(
+			data map[string]string) bool {
+			return strings.Contains(data["line"], "echo") && strings.Contains(data["line"], "a") && strings.Contains(data["line"], "b") && strings.Contains(data["line"], "c")
+		})).Return()
+
 		logger.On("Info", mock.Anything).Return()
 		logger.On("Debug", mock.Anything).Return()
 


### PR DESCRIPTION
This pull request introduces an enhancement to the command runner by emitting a log entry when a command starts, and updates the corresponding test to verify this behavior.

**Command Runner Improvements:**

* Added a new method `sendStartingLine` to `DefaultRunner` in `runner.go`, which emits a log entry with the command being executed in colored formatting before the command starts.
* Updated `RunCommand` to call `sendStartingLine` prior to starting the command process, improving visibility into command execution.

**Testing Updates:**

* Modified `runner_test.go` to import `strings` for enhanced test assertions.
* Added a test expectation in `TestDefaultRunner_RunCommand` to check that the emitted log entry contains the command and relevant output lines, ensuring the new starting line emission is covered by tests.