### PR TITLE
fix: send empty array when there are no env paths in the db

### DIFF
--- a/internal/config/infrastructure/mapper.go
+++ b/internal/config/infrastructure/mapper.go
@@ -9,6 +9,7 @@ func ToDomainConfig(model *ConfigModel, paths []EnvironmentPathModel) *domain.Co
 
 	config := &domain.Config{
 		LastOpenedProjectId: model.LastOpenedProjectId,
+		EnvironmentPaths:    make([]domain.EnvironmentPath, 0),
 	}
 
 	for _, pathModel := range paths {


### PR DESCRIPTION
This pull request introduces a minor improvement to the `ToDomainConfig` function in `internal/config/infrastructure/mapper.go`. The change initializes the `EnvironmentPaths` field with an empty slice, which helps prevent potential nil slice issues when the field is accessed.