### PR TITLE
feat: add language selector to user settings

### DIFF
--- a/cmd/gomander/frontend/src/screens/SettingsScreen/contexts/settingsContext.tsx
+++ b/cmd/gomander/frontend/src/screens/SettingsScreen/contexts/settingsContext.tsx
@@ -1,10 +1,12 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createContext, useContext } from "react";
 import { useForm, type UseFormReturn } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 
 import { useTheme } from "@/contexts/theme.tsx";
+import { translationsService } from "@/contracts/service.ts";
 import { parseError } from "@/helpers/errorHelpers.ts";
 import { fetchProject } from "@/queries/fetchProject.ts";
 import { fetchUserConfig } from "@/queries/fetchUserConfig.ts";
@@ -55,6 +57,7 @@ export const SettingsContextProvider = ({
   const userConfig = useUserConfigurationStore((state) => state.userConfig);
   const projectInfo = useProjectStore((state) => state.projectInfo);
   const { rawTheme, setRawTheme } = useTheme();
+  const { i18n } = useTranslation();
 
   const navigate = useNavigate();
   const { state } = useLocation();
@@ -67,6 +70,7 @@ export const SettingsContextProvider = ({
       environmentPaths: userConfig.environmentPaths,
       theme: rawTheme,
       logLineLimit: userConfig.logLineLimit,
+      locale: i18n.language,
       name: projectInfo?.name || "",
       baseWorkingDirectory: projectInfo?.workingDirectory || "",
     },
@@ -80,9 +84,18 @@ export const SettingsContextProvider = ({
     },
   });
 
+  const loadLanguage = async (lang: string) => {
+    if (!i18n.hasResourceBundle(lang, "translation")) {
+      const translations = await translationsService.getTranslation(lang);
+      i18n.addResourceBundle(lang, "translation", translations);
+    }
+
+    await i18n.changeLanguage(lang);
+  };
+
   const { dirtyFields } = settingsForm.formState;
 
-  const hasUserChanges = !!dirtyFields.environmentPaths || !!dirtyFields.logLineLimit;
+  const hasUserChanges = !!dirtyFields.environmentPaths || !!dirtyFields.logLineLimit || !!dirtyFields.locale;
   const hasProjectChanges =
     dirtyFields.name || dirtyFields.baseWorkingDirectory;
   const saveSettings = async (formData: SettingsFormType) => {
@@ -93,11 +106,12 @@ export const SettingsContextProvider = ({
     // Save user settings
     if (hasUserChanges) {
       try {
+        await loadLanguage(formData.locale);
         await saveUserConfig({
           lastOpenedProjectId: userConfig.lastOpenedProjectId,
           environmentPaths: formData.environmentPaths,
           logLineLimit: formData.logLineLimit,
-          locale: 'en-GB', // TODO: add this to formData
+          locale: formData.locale,
         });
         toast.success("User settings saved successfully");
       } catch (e) {

--- a/cmd/gomander/frontend/src/screens/SettingsScreen/contexts/settingsFormSchema.ts
+++ b/cmd/gomander/frontend/src/screens/SettingsScreen/contexts/settingsFormSchema.ts
@@ -16,6 +16,7 @@ export const settingsFormSchema = z.object({
     .int()
     .min(1, "Must be at least 1")
     .max(5000, "Must be at most 5000"),
+  locale: z.string(),
   // Project settings schema
   name: z.string().min(1, "Project name is required"),
   baseWorkingDirectory: z.string().min(1, "Base working directory is required"),

--- a/cmd/gomander/frontend/src/screens/SettingsScreen/tabs/UserSettings/UserSettings.tsx
+++ b/cmd/gomander/frontend/src/screens/SettingsScreen/tabs/UserSettings/UserSettings.tsx
@@ -1,4 +1,6 @@
 import { Route, Save, WandSparkles } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { Button } from "@/design-system/components/ui/button.tsx";
 import {
@@ -25,13 +27,30 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/design-system/components/ui/select";
+import { translationsService } from "@/contracts/service";
 import { useSettingsContext } from "@/screens/SettingsScreen/contexts/settingsContext.tsx";
 import { EnvironmentPathsField } from "@/screens/SettingsScreen/tabs/ProjectSettings/components/EnvironmentPathsField.tsx";
 import { EnvironmentPathsInfoDialog } from "@/screens/SettingsScreen/tabs/UserSettings/components/EnvironmentPathsInfoDialog.tsx";
 
 export const UserSettings = () => {
+  const { t } = useTranslation();
+
   const { settingsForm, saveSettings, hasUnsavedChanges } =
     useSettingsContext();
+  const [supportedLanguages, setSupportedLanguages] = useState<string[]>([]);
+
+  useEffect(() => {
+    const loadSupportedLanguages = async () => {
+      try {
+        const languages = await translationsService.getSupportedLanguages();
+        setSupportedLanguages(languages);
+      } catch (error) {
+        console.error("Failed to load supported languages:", error);
+      }
+    };
+
+    loadSupportedLanguages();
+  }, []);
 
   return (
     <Form {...settingsForm}>
@@ -63,66 +82,97 @@ export const UserSettings = () => {
               </CardTitle>
               <CardDescription>Make gomander your own!</CardDescription>
             </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <FormField
-                  control={settingsForm.control}
-                  name="theme"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Theme</FormLabel>
-                      <FormControl>
-                        <Select
-                          onValueChange={field.onChange}
-                          defaultValue={field.value}
-                        >
-                          <FormControl>
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select your preferred theme" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            <SelectItem value="system">System theme</SelectItem>
-                            <SelectItem value="light">Light theme</SelectItem>
-                            <SelectItem value="dark">Dark theme</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                      <FormDescription className="text-xs">
-                        (The system theme will adapt to your operating system's
-                        theme settings)
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={settingsForm.control}
-                  name="logLineLimit"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Log line limit</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="number"
-                          min={1}
-                          max={5000}
-                          {...field}
-                          onChange={(e) =>
-                            field.onChange(Number(e.target.value))
-                          }
-                        />
-                      </FormControl>
-                      <FormDescription className="text-xs">
-                        Maximum number of log lines to keep per command
-                        (1-5000). The recommended value is 100. Bigger values
-                        may impact performance.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
+            <CardContent className="space-y-3">
+              <FormField
+                control={settingsForm.control}
+                name="locale"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Language</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select your preferred language" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {supportedLanguages.map((language) => (
+                            <SelectItem key={language} value={language}>
+                              {language === "en"
+                                ? "English"
+                                : language === "es"
+                                  ? "Español"
+                                  : language}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={settingsForm.control}
+                name="theme"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Theme</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select your preferred theme" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="system">System theme</SelectItem>
+                          <SelectItem value="light">Light theme</SelectItem>
+                          <SelectItem value="dark">Dark theme</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormDescription className="text-xs">
+                      (The system theme will adapt to your operating system's
+                      theme settings)
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={settingsForm.control}
+                name="logLineLimit"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Log line limit</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={5000}
+                        {...field}
+                        onChange={(e) =>
+                          field.onChange(Number(e.target.value))
+                        }
+                      />
+                    </FormControl>
+                    <FormDescription className="text-xs">
+                      Maximum number of log lines to keep per command
+                      (1-5000). The recommended value is 100. Bigger values
+                      may impact performance.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </CardContent>
           </Card>
         </div>
@@ -132,7 +182,7 @@ export const UserSettings = () => {
           disabled={!hasUnsavedChanges}
         >
           <Save />
-          Save
+          {t("actions.save")}
         </Button>
       </form>
     </Form>

--- a/cmd/gomander/frontend/src/screens/SettingsScreen/tabs/UserSettings/UserSettings.tsx
+++ b/cmd/gomander/frontend/src/screens/SettingsScreen/tabs/UserSettings/UserSettings.tsx
@@ -1,5 +1,4 @@
 import { Route, Save, WandSparkles } from "lucide-react";
-import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/design-system/components/ui/button.tsx";
@@ -27,7 +26,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/design-system/components/ui/select";
-import { translationsService } from "@/contracts/service";
 import { useSettingsContext } from "@/screens/SettingsScreen/contexts/settingsContext.tsx";
 import { EnvironmentPathsField } from "@/screens/SettingsScreen/tabs/ProjectSettings/components/EnvironmentPathsField.tsx";
 import { EnvironmentPathsInfoDialog } from "@/screens/SettingsScreen/tabs/UserSettings/components/EnvironmentPathsInfoDialog.tsx";
@@ -35,22 +33,8 @@ import { EnvironmentPathsInfoDialog } from "@/screens/SettingsScreen/tabs/UserSe
 export const UserSettings = () => {
   const { t } = useTranslation();
 
-  const { settingsForm, saveSettings, hasUnsavedChanges } =
+  const { settingsForm, saveSettings, hasUnsavedChanges, supportedLanguages } =
     useSettingsContext();
-  const [supportedLanguages, setSupportedLanguages] = useState<string[]>([]);
-
-  useEffect(() => {
-    const loadSupportedLanguages = async () => {
-      try {
-        const languages = await translationsService.getSupportedLanguages();
-        setSupportedLanguages(languages);
-      } catch (error) {
-        console.error("Failed to load supported languages:", error);
-      }
-    };
-
-    loadSupportedLanguages();
-  }, []);
 
   return (
     <Form {...settingsForm}>
@@ -101,12 +85,11 @@ export const UserSettings = () => {
                         </FormControl>
                         <SelectContent>
                           {supportedLanguages.map((language) => (
-                            <SelectItem key={language} value={language}>
-                              {language === "en"
-                                ? "English"
-                                : language === "es"
-                                  ? "Español"
-                                  : language}
+                            <SelectItem
+                              key={language.value}
+                              value={language.value}
+                            >
+                              {language.label}
                             </SelectItem>
                           ))}
                         </SelectContent>


### PR DESCRIPTION
## Summary
Adds a language selector dropdown to the User Settings tab, enabling users to change the application language between English and Spanish. The language selection integrates with the existing i18n system and persists changes through the settings save workflow.

## Changes
- **UI Components**: Added language dropdown in UserSettings with supported languages
- **Form Schema**: Extended settings schema to include `locale` field  
- **Context Logic**: Centralized supported languages query in settings context with value/label mapping
- **Language Integration**: Implemented dynamic language loading and i18n resource bundling
- **Persistence**: Language changes persist through existing settings save mechanism

## Technical Implementation
- Language changes apply on "Save" button click (unlike theme which applies immediately) - this decision prioritizes simplicity in anticipation of issue #116 where the Save button will be removed entirely
- Dynamic resource loading prevents initial bloat - languages loaded on-demand when selected
- Centralized `supportedLanguages` array in context with `{value, label}` objects for clean UI rendering
- Used existing `translationsService.getSupportedLanguages()` and `loadLanguage()` pattern

## Testing
- ✅ Language selector loads available languages from backend
- ✅ Language selection shows proper labels (English/Español)
- ✅ Language change applies immediately on Save
- ✅ Language preference persists after app restart
- ✅ Form validation and dirty state detection works correctly

## Next Steps
- Issue #116
- Translation coverage expansion: Systematically replace hardcoded text across all components with translation keys
- Add a README specific section under "Contribute" with a guide on how to add languages

## Related
- Stacked on PR #175
- Stacked on PR #174