### PR TITLE
fix: prevent FSInput button from submitting forms

### DIFF
--- a/cmd/gomander/frontend/src/components/inputs/FSInput.tsx
+++ b/cmd/gomander/frontend/src/components/inputs/FSInput.tsx
@@ -19,6 +19,7 @@ export const FSInput = (props: React.ComponentProps<typeof Input>) => {
     <div className="w-full relative">
       <Input {...props} className={cn("pr-8", props.className)} />
       <button
+        type="button"
         onClick={handleAskForDirPath}
         className="absolute right-2 top-2 z-10 bg-background"
       >


### PR DESCRIPTION
## Summary
- Fixed FSInput button to prevent unintended form submissions by adding `type="button"`

## Problem
The FSInput component's folder icon button was missing an explicit `type` attribute, causing it to default to `type="submit"` and submit forms when clicked.

## Solution  
Added `type="button"` to the button element in FSInput.tsx to prevent form submission behavior.

## Test plan
- [x] Verify FSInput button no longer submits forms when clicked
- [x] Test that folder selection functionality still works correctly