### PR TITLE
fix: preserve all command fields when duplicating

### DIFF
--- a/internal/command/application/usecases/duplicatecommand.go
+++ b/internal/command/application/usecases/duplicatecommand.go
@@ -45,14 +45,12 @@ func (uc *DefaultDuplicateCommand) Execute(commandId, targetGroupId string) erro
 		return err
 	}
 
-	duplicatedCommand := domain.Command{
-		Id:               uuid.New().String(),
-		ProjectId:        originalCommand.ProjectId,
-		Name:             originalCommand.Name + " (copy)",
-		Command:          originalCommand.Command,
-		WorkingDirectory: originalCommand.WorkingDirectory,
-		Position:         len(allCommands),
-	}
+	duplicatedCommand := *originalCommand
+
+	// Override specific fields
+	duplicatedCommand.Id = uuid.New().String()
+	duplicatedCommand.Name = originalCommand.Name + " (copy)"
+	duplicatedCommand.Position = len(allCommands)
 
 	err = uc.commandRepository.Create(&duplicatedCommand)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes the duplicate command functionality to preserve all fields from the original command, including `Link` and `ErrorPatterns`, which were previously being lost during duplication.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or improvement

## Changes Made

- Refactored `duplicatecommand.go` to use struct copying instead of manual field assignment
- Changed from initializing a new `Command` struct with specific fields to copying the entire original command and overriding only the fields that should differ (Id, Name, Position)
- This ensures all fields including `Link` and `ErrorPatterns` are automatically preserved

## Testing

Describe how this change was tested:

- [x] Manual testing performed
- [x] Existing tests pass (`go test ./...`)
- [ ] New tests added for new functionality:
    - N/A - bug fix for existing functionality
- [x] Application builds successfully (`make all`)
- [x] Tested in development mode (`make dev`)

## Screenshots/Examples

N/A

## Checklist

Please review the [Contributing Guidelines](CONTRIBUTING.md) and ensure your PR meets these requirements:

### Code Quality
- [x] Code follows project style guidelines
- [x] Linting and formatting checks pass (`make lint`)

### Architecture & Design
- [ ] Changes follow Clean Architecture principles
- [ ] Backend uses proper dependency injection
- [ ] Frontend components are focused and reusable
- [ ] Database migrations created if schema changes are needed

### Documentation & Communication
- [ ] Documentation updated (if user-facing changes)
- [x] Commit messages follow [conventional commit format](https://www.conventionalcommits.org/)
- [x] Changes are focused and atomic
- [x] PR title clearly describes the change

### Related Issues

Closes #200

## Additional Notes

This approach is more maintainable - if new fields are added to the `Command` entity in the future, they will automatically be included in duplicated commands without needing to update this use case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal command duplication logic for better efficiency while maintaining existing functionality.

**Note:** This update includes no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->