### PR TITLE
chore(ui): minor UI and copy improvements

### DIFF
--- a/cmd/gomander/frontend/src/components/modals/Command/CreateCommandModal.tsx
+++ b/cmd/gomander/frontend/src/components/modals/Command/CreateCommandModal.tsx
@@ -105,7 +105,6 @@ export const CreateCommandModal = ({
               <div className="space-y-6">
                 <CommandNameField />
                 <CommandCommandField />
-                <CommandLinkField />
                 <CommandWorkingDirectoryField />
                 <CommandComputedPath />
               </div>
@@ -113,7 +112,10 @@ export const CreateCommandModal = ({
                 <AccordionItem value="1">
                   <AccordionTrigger>{t('common.advanced')}</AccordionTrigger>
                   <AccordionContent>
-                    <CommandErrorPatternsField />
+                    <div className="space-y-6">
+                      <CommandLinkField />
+                      <CommandErrorPatternsField />
+                    </div>
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>

--- a/cmd/gomander/frontend/src/components/modals/Command/EditCommandModal.tsx
+++ b/cmd/gomander/frontend/src/components/modals/Command/EditCommandModal.tsx
@@ -106,7 +106,6 @@ export const EditCommandModal = ({
               <div className="space-y-6">
                 <CommandNameField />
                 <CommandCommandField />
-                <CommandLinkField />
                 <CommandWorkingDirectoryField />
                 <CommandComputedPath />
               </div>
@@ -114,7 +113,10 @@ export const EditCommandModal = ({
                 <AccordionItem value="1">
                   <AccordionTrigger>{t('common.advanced')}</AccordionTrigger>
                   <AccordionContent>
-                    <CommandErrorPatternsField />
+                    <div className="space-y-6">
+                      <CommandLinkField />
+                      <CommandErrorPatternsField />
+                    </div>
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>

--- a/cmd/gomander/locales/en.json
+++ b/cmd/gomander/locales/en.json
@@ -48,7 +48,7 @@
   "aboutModal.newVersion": "Version {{version}} is available",
   "aboutModal.newVersionSubtitle": "Get the latest features and improvements",
   "aboutModal.downloadUpdate": "Download Update",
-  "aboutModal.description": "A simple GUI for managing and organizing your development commands. Built to streamline your workflow and eliminate terminal chaos.",
+  "aboutModal.description": "Organize and launch your development commands from a single place. Built to streamline your workflow and eliminate terminal chaos.",
   "aboutModal.feedbackTitle": "Any feedback?",
   "aboutModal.feedbackSubtitle": "Visit our GitHub repository",
   "aboutModal.teamTitle": "Meet the Team",

--- a/cmd/gomander/locales/es.json
+++ b/cmd/gomander/locales/es.json
@@ -48,7 +48,7 @@
   "aboutModal.newVersion": "La versión {{version}} está disponible",
   "aboutModal.newVersionSubtitle": "Obtén las últimas novedades y mejoras",
   "aboutModal.downloadUpdate": "Descargar actualización",
-  "aboutModal.description": "Una interfaz gráfica sencilla para gestionar y organizar tus comandos de desarrollo. Diseñada para optimizar tu flujo de trabajo y eliminar el caos de la terminal.",
+  "aboutModal.description": "Organiza y lanza todos tus comandos de desarrollo desde un único lugar. Diseñado para simplificar tu flujo de trabajo y acabar con el caos de las terminales.",
   "aboutModal.feedbackTitle": "¿Tienes algún comentario?",
   "aboutModal.feedbackSubtitle": "Visita nuestro repositorio de GitHub",
   "aboutModal.teamTitle": "Conoce al equipo",


### PR DESCRIPTION
## Problem

Small UX and copy inconsistencies introduced in recent commits: the Link field in command modals appeared in the main section rather than under Advanced, and the About modal description felt too technical.

## Solution

- **Command modals (Create & Edit)**
    - Moved `CommandLinkField` from the main section into the Advanced accordion, grouped with `CommandErrorPatternsField`
    - Wrapped both fields in a `space-y-6` container for consistent spacing

- **i18n copies**
    - Updated `aboutModal.description` in EN and ES to use clearer, more user-friendly language

### Testing
- ✅ Visually verified in both Create and Edit command modals
- ✅ Locale strings updated in EN and ES