### PR TITLE
chore(releases): bump version to v1.2.0

### DIFF
--- a/internal/releases/release.go
+++ b/internal/releases/release.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-const CurrentRelease = "v1.1.0"
+const CurrentRelease = "v1.2.0"
 
 const RepoOwnerAndName = "Lazylabz/gomander-app"
 

--- a/internal/releases/release_test.go
+++ b/internal/releases/release_test.go
@@ -20,7 +20,7 @@ func TestApp_GetCurrentRelease(t *testing.T) {
 	currentRelease := rh.GetCurrentRelease()
 
 	// Assert
-	assert.Equal(t, "1.1.0", currentRelease)
+	assert.Equal(t, "1.2.0", currentRelease)
 
 	// Verify it's a valid semver
 	_, err := semver.NewVersion(currentRelease)


### PR DESCRIPTION
## Problem

The app was still pointing to v1.1.0 after the features shipped in this release cycle.

## Solution

Bumps `CurrentRelease` constant from `v1.1.0` to `v1.2.0` and updates the corresponding test assertion.

### Testing
- ✅ Unit test updated and passing (`go test ./...`, 302 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to v1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->