### PR TITLE
feat(command): notify when a command may fail due to missing environment paths

### DIFF
--- a/cmd/gomander/frontend/src/App.tsx
+++ b/cmd/gomander/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Route, Routes } from "react-router";
 
 import { AppSidebarLayout } from "@/components/layout/AppSidebarLayout/AppSidebarLayout.tsx";
+import { MissingEnvironmentPathDialog } from "@/components/MissingEnvironmentPath/MissingEnvironmentPathDialog.tsx";
 import { EventListenersContainer } from "@/components/utility/EventListenersContainer.tsx";
 import { ThemeProvider } from "@/contexts/theme.tsx";
 import { VersionProvider } from "@/contexts/version.tsx";
@@ -52,6 +53,7 @@ function App() {
 		<VersionProvider>
 			<ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
 				<EventListenersContainer />
+				<MissingEnvironmentPathDialog />
 				<Toaster richColors position="top-right" />
 				<Routes>
 					<Route

--- a/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathDialog.tsx
+++ b/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathDialog.tsx
@@ -1,0 +1,76 @@
+import { Trans, useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+
+import { Button } from "@/design-system/components/ui/button.tsx";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/design-system/components/ui/dialog.tsx";
+import { ScreenRoutes } from "@/routes.ts";
+import { SettingsTab } from "@/screens/SettingsScreen/context/settingsContext.tsx";
+import { useMissingEnvironmentPathStore } from "@/store/missingEnvironmentPathStore.ts";
+
+export const MissingEnvironmentPathDialog = () => {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+
+	const dialogOpen = useMissingEnvironmentPathStore(
+		(state) => state.dialogOpen,
+	);
+	const setDialogOpen = useMissingEnvironmentPathStore(
+		(state) => state.setDialogOpen,
+	);
+
+	const handleGoToSettings = () => {
+		setDialogOpen(false);
+		navigate(ScreenRoutes.Settings, { state: { tab: SettingsTab.User } });
+	};
+
+	return (
+		<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+			<DialogContent className="[&_code]:bg-accent [&_code]:rounded [&_code]:px-1">
+				<DialogHeader>
+					<DialogTitle>{t("modal.missingPath.title")}</DialogTitle>
+					<DialogDescription asChild>
+						<p className="text-sm text-muted-foreground">
+							<Trans
+								i18nKey="modal.missingPath.description"
+								components={{ code: <code /> }}
+							/>
+						</p>
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-2 text-sm">
+					<p className="font-medium">{t("modal.missingPath.howToTitle")}</p>
+					<ol className="list-decimal flex flex-col gap-1 pl-5">
+						<li>
+							<Trans
+								i18nKey="modal.missingPath.howToStep1"
+								components={{
+									whichcmd: (
+										<code>which {t("modal.missingPath.commandPlaceholder")}</code>
+									),
+									wherecmd: (
+										<code>where {t("modal.missingPath.commandPlaceholder")}</code>
+									),
+								}}
+							/>
+						</li>
+						<li>{t("modal.missingPath.howToStep2")}</li>
+					</ol>
+				</div>
+
+				<DialogFooter>
+					<Button type="button" onClick={handleGoToSettings}>
+						{t("modal.missingPath.goToSettings")}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathDialog.tsx
+++ b/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathDialog.tsx
@@ -53,10 +53,14 @@ export const MissingEnvironmentPathDialog = () => {
 								i18nKey="modal.missingPath.howToStep1"
 								components={{
 									whichcmd: (
-										<code>which {t("modal.missingPath.commandPlaceholder")}</code>
+										<code>
+											which {t("modal.missingPath.commandPlaceholder")}
+										</code>
 									),
 									wherecmd: (
-										<code>where {t("modal.missingPath.commandPlaceholder")}</code>
+										<code>
+											where {t("modal.missingPath.commandPlaceholder")}
+										</code>
 									),
 								}}
 							/>

--- a/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathToast.tsx
+++ b/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathToast.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import { missingEnvironmentPathStore } from "@/store/missingEnvironmentPathStore.ts";
+
+export const MISSING_ENV_PATH_TOAST_ID = "missing-environment-path";
+
+export const MissingEnvironmentPathToast = () => {
+	const { t } = useTranslation();
+
+	const handleLearnMore = () => {
+		missingEnvironmentPathStore.getState().setDialogOpen(true);
+		toast.dismiss(MISSING_ENV_PATH_TOAST_ID);
+	};
+
+	return (
+		<div className="flex flex-col gap-2 items-start">
+			<p>{t("toast.missingPath.message")}</p>
+			<button
+				type="button"
+				className="underline"
+				onClick={handleLearnMore}
+			>
+				{t("toast.missingPath.action")}
+			</button>
+		</div>
+	);
+};

--- a/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathToast.tsx
+++ b/cmd/gomander/frontend/src/components/MissingEnvironmentPath/MissingEnvironmentPathToast.tsx
@@ -16,11 +16,7 @@ export const MissingEnvironmentPathToast = () => {
 	return (
 		<div className="flex flex-col gap-2 items-start">
 			<p>{t("toast.missingPath.message")}</p>
-			<button
-				type="button"
-				className="underline"
-				onClick={handleLearnMore}
-			>
+			<button type="button" className="underline" onClick={handleLearnMore}>
 				{t("toast.missingPath.action")}
 			</button>
 		</div>

--- a/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
+++ b/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
@@ -14,6 +14,7 @@ import { terminalStore } from "@/store/terminalStore.ts";
 import { useUserConfigurationStore } from "@/store/userConfigurationStore.ts";
 import { CommandStatus } from "@/types/CommandStatus.ts";
 import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
+import { detectMissingEnvironmentPathFailure } from "@/useCases/command/detectMissingEnvironmentPathFailure.tsx";
 import { recordCommandsErrors } from "@/useCases/command/recordCommandsErrors.ts";
 import { updateCommandStatus } from "@/useCases/command/updateCommandStatus.ts";
 import { XTERM_THEMES } from "../../screens/ExperimentalLogsScreen/components/CommandTerminal.tsx";
@@ -76,8 +77,13 @@ export const EventListenersContainer = () => {
 
 		eventService.eventsOn(
 			Event.PROCESS_FINISHED,
-			(data: EventData[Event.PROCESS_FINISHED]) =>
-				updateCommandStatus(data, CommandStatus.IDLE),
+			(data: EventData[Event.PROCESS_FINISHED]) => {
+				updateCommandStatus(data, CommandStatus.IDLE);
+				detectMissingEnvironmentPathFailure(
+					data,
+					logsBuffer.current.get(data) ?? [],
+				);
+			},
 		);
 
 		eventService.eventsOn(

--- a/cmd/gomander/frontend/src/store/missingEnvironmentPathStore.ts
+++ b/cmd/gomander/frontend/src/store/missingEnvironmentPathStore.ts
@@ -1,0 +1,19 @@
+import { useStore } from "zustand/react";
+import { createStore } from "zustand/vanilla";
+
+type MissingEnvironmentPathStore = {
+	dialogOpen: boolean;
+	setDialogOpen: (open: boolean) => void;
+};
+
+// To be used in use cases
+export const missingEnvironmentPathStore =
+	createStore<MissingEnvironmentPathStore>()((set) => ({
+		dialogOpen: false,
+		setDialogOpen: (open) => set({ dialogOpen: open }),
+	}));
+
+// To be used in react components
+export const useMissingEnvironmentPathStore = <T>(
+	selector: (state: MissingEnvironmentPathStore) => T,
+): T => useStore(missingEnvironmentPathStore, selector);

--- a/cmd/gomander/frontend/src/useCases/command/detectMissingEnvironmentPathFailure.tsx
+++ b/cmd/gomander/frontend/src/useCases/command/detectMissingEnvironmentPathFailure.tsx
@@ -6,10 +6,14 @@ import {
 } from "@/components/MissingEnvironmentPath/MissingEnvironmentPathToast.tsx";
 import { commandStore } from "@/store/commandStore.ts";
 
+// Shell/OS specific wording for "this executable could not be located".
 // "No such file or directory" is intentionally excluded as it is too noisy.
 const MISSING_PATH_PATTERNS = [
-	/: command not found/i,
-	/executable file not found in \$?path/i,
+	/: command not found/i, // bash, zsh
+	/: not found/i, // dash, sh, busybox ("sh: 1: foo: not found")
+	/unknown command/i, // fish ("fish: Unknown command: foo")
+	/is not recognized as an internal or external command/i, // Windows cmd.exe
+	/executable file not found in \$?path/i, // Go exec
 ];
 
 const isMissingPathLine = (line: string): boolean =>

--- a/cmd/gomander/frontend/src/useCases/command/detectMissingEnvironmentPathFailure.tsx
+++ b/cmd/gomander/frontend/src/useCases/command/detectMissingEnvironmentPathFailure.tsx
@@ -1,0 +1,38 @@
+import { toast } from "sonner";
+
+import {
+	MISSING_ENV_PATH_TOAST_ID,
+	MissingEnvironmentPathToast,
+} from "@/components/MissingEnvironmentPath/MissingEnvironmentPathToast.tsx";
+import { commandStore } from "@/store/commandStore.ts";
+
+// "No such file or directory" is intentionally excluded as it is too noisy.
+const MISSING_PATH_PATTERNS = [
+	/: command not found/i,
+	/executable file not found in \$?path/i,
+];
+
+const isMissingPathLine = (line: string): boolean =>
+	MISSING_PATH_PATTERNS.some((pattern) => pattern.test(line));
+
+// The error is emitted as the process exits, so it lands in the last log lines.
+const LINES_TO_SCAN = 20;
+
+// `bufferedLines` are lines not yet flushed from the buffer into the store; we
+// scan them alongside stored logs so the final error line is never missed.
+export const detectMissingEnvironmentPathFailure = (
+	commandId: string,
+	bufferedLines: string[] = [],
+): void => {
+	const storedLines = commandStore.getState().commandsLogs[commandId] ?? [];
+	const lastLines = [...storedLines, ...bufferedLines].slice(-LINES_TO_SCAN);
+
+	if (!lastLines.some(isMissingPathLine)) {
+		return;
+	}
+
+	toast.warning(<MissingEnvironmentPathToast />, {
+		id: MISSING_ENV_PATH_TOAST_ID,
+		icon: null,
+	});
+};

--- a/cmd/gomander/frontend/wailsjs/go/models.ts
+++ b/cmd/gomander/frontend/wailsjs/go/models.ts
@@ -262,6 +262,15 @@ export namespace domain {
 	    "toast.version.checkError": string;
 	    "toast.version.downloadFailed": string;
 	    "toast.version.installFailed": string;
+	    "toast.missingPath.message": string;
+	    "toast.missingPath.action": string;
+	    "modal.missingPath.title": string;
+	    "modal.missingPath.description": string;
+	    "modal.missingPath.howToTitle": string;
+	    "modal.missingPath.howToStep1": string;
+	    "modal.missingPath.howToStep2": string;
+	    "modal.missingPath.commandPlaceholder": string;
+	    "modal.missingPath.goToSettings": string;
 	}
 	export interface Project {
 	    id: string;

--- a/cmd/gomander/locales/en.json
+++ b/cmd/gomander/locales/en.json
@@ -177,5 +177,16 @@
 
   "toast.version.checkError": "Error checking for new releases",
   "toast.version.downloadFailed": "Failed to download the update",
-  "toast.version.installFailed": "Failed to install the update"
+  "toast.version.installFailed": "Failed to install the update",
+
+  "toast.missingPath.message": "A command may have failed because its executable wasn't found in your environment paths.",
+  "toast.missingPath.action": "Learn more",
+
+  "modal.missingPath.title": "Possible missing environment path",
+  "modal.missingPath.description": "One of your commands exited with a \"command not found\" error. This usually means the executable isn't available in the environment paths Gomander uses to run your commands. This often happens with version managers like <code>nvm</code> or <code>pyenv</code>, whose paths are normally set by files such as <code>.bashrc</code>, <code>.zshrc</code> or <code>.profile</code>.",
+  "modal.missingPath.howToTitle": "How to fix it",
+  "modal.missingPath.howToStep1": "Find where the executable lives by running <whichcmd/> (macOS/Linux) or <wherecmd/> (Windows) in your terminal.",
+  "modal.missingPath.howToStep2": "Copy the directory that contains it and add it to your environment paths in Settings.",
+  "modal.missingPath.commandPlaceholder": "<command>",
+  "modal.missingPath.goToSettings": "Open settings"
 }

--- a/cmd/gomander/locales/es.json
+++ b/cmd/gomander/locales/es.json
@@ -177,5 +177,16 @@
 
   "toast.version.checkError": "Error al comprobar nuevas versiones",
   "toast.version.downloadFailed": "Error al descargar la actualización",
-  "toast.version.installFailed": "Error al instalar la actualización"
+  "toast.version.installFailed": "Error al instalar la actualización",
+
+  "toast.missingPath.message": "Puede que un comando haya fallado porque no se encontró su ejecutable en tus rutas de entorno.",
+  "toast.missingPath.action": "Más información",
+
+  "modal.missingPath.title": "Posible ruta de entorno ausente",
+  "modal.missingPath.description": "Uno de tus comandos terminó con un error \"command not found\". Esto suele significar que el ejecutable no está disponible en las rutas de entorno que Gomander usa para ejecutar tus comandos. Es habitual con gestores de versiones como <code>nvm</code> o <code>pyenv</code>, cuyas rutas normalmente las definen archivos como <code>.bashrc</code>, <code>.zshrc</code> o <code>.profile</code>.",
+  "modal.missingPath.howToTitle": "Cómo solucionarlo",
+  "modal.missingPath.howToStep1": "Averigua dónde está el ejecutable ejecutando <whichcmd/> (macOS/Linux) o <wherecmd/> (Windows) en tu terminal.",
+  "modal.missingPath.howToStep2": "Copia el directorio que lo contiene y añádelo a tus rutas de entorno en Ajustes.",
+  "modal.missingPath.commandPlaceholder": "<comando>",
+  "modal.missingPath.goToSettings": "Abrir ajustes"
 }

--- a/internal/localization/domain/localization.go
+++ b/internal/localization/domain/localization.go
@@ -198,4 +198,17 @@ type Localization struct {
 	ToastVersionCheckError     string `json:"toast.version.checkError"`
 	ToastVersionDownloadFailed string `json:"toast.version.downloadFailed"`
 	ToastVersionInstallFailed  string `json:"toast.version.installFailed"`
+
+	// toast.missingPath
+	ToastMissingPathMessage string `json:"toast.missingPath.message"`
+	ToastMissingPathAction  string `json:"toast.missingPath.action"`
+
+	// modal.missingPath
+	ModalMissingPathTitle              string `json:"modal.missingPath.title"`
+	ModalMissingPathDescription        string `json:"modal.missingPath.description"`
+	ModalMissingPathHowToTitle         string `json:"modal.missingPath.howToTitle"`
+	ModalMissingPathHowToStep1         string `json:"modal.missingPath.howToStep1"`
+	ModalMissingPathHowToStep2         string `json:"modal.missingPath.howToStep2"`
+	ModalMissingPathCommandPlaceholder string `json:"modal.missingPath.commandPlaceholder"`
+	ModalMissingPathGoToSettings       string `json:"modal.missingPath.goToSettings"`
 }


### PR DESCRIPTION
## Summary

When a command fails because its executable isn't on the configured environment `PATH`, the failure was silent and easy to misdiagnose. This adds a lightweight, non-intrusive hint: a single warning toast that, when clicked, explains the likely cause and points the user to where they can fix it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Detect probable missing-PATH failures on the frontend by scanning the last log lines of a finished command for `command not found` / `executable file not found in $PATH` (conservative patterns; `No such file or directory` deliberately excluded to avoid false positives).
- Show a single deduplicated warning toast (fixed id, so it never stacks); clicking it opens a dialog explaining the cause, how to locate the executable with `which`/`where`, and a button that navigates to User settings → environment paths.
- Add i18n strings (en/es) and the matching `Localization` struct fields; regenerate Wails bindings.

## Testing

Describe how this change was tested:

- [x] Manual testing performed
- [x] Existing tests pass (`go test ./...`) — 317 passed
- [ ] New tests added for new functionality
- [x] Application builds successfully (`make all`)
- [x] Tested in development mode (`make dev`)

> Note: frontend `pnpm run typecheck` passes. `make lint` / `make dev` not run in this environment — please verify the toast/dialog visually before merge.

## Screenshots/Examples

<!-- TODO: add a screenshot of the toast + dialog -->

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Linting and formatting checks pass (`make lint`)

### Architecture & Design
- [x] Changes follow Clean Architecture principles
- [x] Backend uses proper dependency injection
- [x] Frontend components are focused and reusable
- [ ] Database migrations created if schema changes are needed — N/A

### Documentation & Communication
- [ ] Documentation updated (if user-facing changes)
- [x] Commit messages follow conventional commit format
- [x] Changes are focused and atomic
- [x] PR title clearly describes the change

### Related Issues

Closes #196

## Additional Notes

Detection is intentionally conservative to protect user trust (heuristic on log text, no exit code from the backend). Works in both the standard and experimental xterm logs modes since log lines are dual-routed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for missing environment PATH errors when commands fail.
  * A notification toast now alerts users when an executable cannot be found.
  * An informational dialog provides step-by-step instructions to resolve the issue, with a button to navigate directly to settings.
  * Localization support added for English and Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->