### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.23.0'
 
@@ -23,11 +23,11 @@ jobs:
       - name: Verify Go dependencies
         run: go mod verify
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
     name: Push tag when CurrentRelease changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # Use RELEASE_PERSONAL_ACCESS_TOKEN (a PAT with `contents: write`) if

--- a/.github/workflows/test-cov.yml
+++ b/.github/workflows/test-cov.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.23.0'
 
@@ -37,6 +37,6 @@ jobs:
       run: go test -v -coverpkg ./... -coverprofile coverage.txt ./...
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps GitHub Actions across the CI workflows to versions that run on Node.js 24, silencing the deprecation warnings GitHub now emits for Node.js 20 actions (forced to Node.js 24 on June 16th, 2026; Node.js 20 removed from runners September 16th, 2026). `release.yml` was already updated previously and is used as the reference for target versions.

## Type of Change

- [x] Refactoring (no functional changes) — CI tooling only

## Changes Made

- **`lint.yml`**: `checkout@v4→v5`, `setup-go@v5→v6`, `setup-node@v4→v5`, `pnpm/action-setup@v4→v5`
- **`test-cov.yml`**: `checkout@v4→v5`, `setup-go@v5→v6`, `codecov-action@v5→v6` (v6 resolves the internal `github-script` Node 20 warning)
- **`tag-on-version-bump.yml`**: `checkout@v4→v5`

## Testing

- [x] Existing tests pass (validated by the bumped workflows on this PR)
- [ ] Manual testing performed — n/a (CI config only)

## Additional Notes

- Action versions now match `release.yml`, the only workflow already on the newer set.
- The transient `Failed to restore: "/usr/bin/tar" failed with exit code 2` cache error seen on `test (ubuntu-latest)` is unrelated to the Node 20 deprecation and not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow action versions for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->