### PR TITLE
fix(ci): pin the Wails CLI to the version in go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,11 @@ jobs:
           version: 10
 
       - name: Install Wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: |
+          # Pin the CLI to the version in go.mod: @latest can require a newer
+          # Go toolchain than the one setup-go installs (GOTOOLCHAIN=local).
+          wails_version="$(go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)"
+          go install "github.com/wailsapp/wails/v2/cmd/wails@${wails_version}"
 
       - name: Install create-dmg
         run: brew install create-dmg
@@ -89,7 +93,11 @@ jobs:
           version: 10
 
       - name: Install Wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: |
+          # Pin the CLI to the version in go.mod: @latest can require a newer
+          # Go toolchain than the one setup-go installs (GOTOOLCHAIN=local).
+          wails_version="$(go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)"
+          go install "github.com/wailsapp/wails/v2/cmd/wails@${wails_version}"
 
       - name: Install NSIS
         run: |
@@ -155,7 +163,11 @@ jobs:
             libnss3-dev libxss1 libasound2-dev
 
       - name: Install Wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: |
+          # Pin the CLI to the version in go.mod: @latest can require a newer
+          # Go toolchain than the one setup-go installs (GOTOOLCHAIN=local).
+          wails_version="$(go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)"
+          go install "github.com/wailsapp/wails/v2/cmd/wails@${wails_version}"
 
       - name: Build Linux ${{ matrix.arch }} binary
         run: |

--- a/internal/releases/release.go
+++ b/internal/releases/release.go
@@ -20,7 +20,7 @@ const (
 	downloadRequestTimeout      = 10 * time.Minute
 )
 
-const CurrentRelease = "v1.6.0"
+const CurrentRelease = "v1.6.1"
 
 const RepoOwnerAndName = "Lazylabz/gomander-app"
 


### PR DESCRIPTION
## Problem

The v1.6.0 release shipped no binaries. All four build jobs (macOS, Windows, Linux amd64, Linux arm64) failed at the same step:

go: github.com/wailsapp/wails/v2/cmd/wails@latest: github.com/wailsapp/wails/v2@v2.13.0 requires go >= 1.25.0 (running go 1.24.5; GOTOOLCHAIN=local)

The workflow installed the CLI with `@latest`, which now resolves to Wails v2.13.0 and requires Go >= 1.25. `setup-go` installs the toolchain declared in `go.mod` (go1.24.5) and the runners set `GOTOOLCHAIN=local`, so Go cannot silently fetch a newer toolchain — the install just fails. The project itself depends on Wails v2.10.2, so `@latest` was never the version we wanted to build with; it only worked by accident while upstream's minimum Go happened to be low enough.

## Solution

- **Install the CLI version the module already declares**
    - Each of the three "Install Wails CLI" steps now reads the version with `go list -m` and installs that exact tag instead of `@latest`.
    - Derived rather than hardcoded, so bumping the Wails dependency in `go.mod` keeps the CI CLI in step automatically — no second place to remember.

- **Cut the v1.6.1 release**
    - Bumps `CurrentRelease`, which is what `tag-on-version-bump` watches. Merging this tags v1.6.1 and re-runs `release.yml` with the fix in place, avoiding a force re-tag of v1.6.0.

### Testing
- ✅ `go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2` resolves to `v2.10.2` locally.
- ✅ Workflow YAML parses; all three jobs run under bash (the Windows job via its `defaults.run.shell` override), so the command substitution is portable.
- ❌ Not exercised end-to-end — the real verification is the release run triggered by merging this.

### Next Steps
- The empty v1.6.0 draft release should be deleted or left as-is; v1.6.1 supersedes it.
- `go.mod` still pins `toolchain go1.24.5`, so upgrading to Wails v2.13.x remains blocked on moving to Go >= 1.25. Out of scope here.
- `create-release` runs `gh release create` unconditionally, so any re-run of `release.yml` against an existing tag will fail that job and block all three build jobs. Worth making idempotent separately.
